### PR TITLE
Add forwarding logic for query params

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -28,23 +28,29 @@ const setupRoutes = async (oAuth2Client, app) => {
       res.json({ message: "Success!" });
     });
     newRouter.get("/", (req, res) => {
-      res.status(200).send('ScottyLabs Dynamic Routes API');
-    })
+      res.status(200).send("ScottyLabs Dynamic Routes API");
+    });
     newRouter.get("/*", (req, res) => {
-      const path = req.originalUrl;
+      const path = req.path;
       try {
         const found = routePairs.some((entry) => {
           const route = entry[0];
-          const location = entry[1];
+          const location = new URL(entry[1]);
           if (reserved_routes.includes(route)) return false;
           if (path === route) {
-            res.redirect(location);
+            if (req.query) {
+              // Forward URL query params to the destination
+              for (const paramKey in req.query) {
+                location.searchParams.append(paramKey, req.query[paramKey]);
+              }
+            }
+            res.redirect(location.toString());
             return true;
           }
           return false;
         });
         if (!found) {
-          return res.status(404).send("Page not found!" );
+          return res.status(404).send("Page not found!");
         }
       } catch (e) {
         console.log(e);


### PR DESCRIPTION
# Description

Fix issue where having a query parameter would cause a route not to be found. Instead of showing a 404, we should forward the query parameters to the destination.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Using a query parameter on an existing route still goes to the correct route
- [x] Using a query parameter on an existing route will append that parameter to the destination

**Test Configuration**:

<!-- Please remove sections that are not relevant. -->

- Node.js version: 16

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
